### PR TITLE
Remove mocha preinstall script from package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,13 @@
 {
   "name": "gulp-ractive",
   "description": "Precompile ractive templates with Ractive.parse().",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "author": {
     "name": "Max Galbusera",
     "email": "max.galbusera@gmail.com"
   },
   "scripts": {
-    "test": "mocha",
-    "preinstall": "npm install -g mocha"
+    "test": "mocha"
   },
   "dependencies": {
     "gulp-util": "~2.2.14",


### PR DESCRIPTION
Forcing everyone to install mocha globally during package install is not a good idea because :
1. who said everyone wants to run tests ?
2. it can break installation of a whole project if administrator privileges are required to install globally available packages because preinstall scripts are apparently not executed with the same privileges as the `npm install` command...

I also incremented package version so please do a `npm publish` after merge, thank you :)
